### PR TITLE
Merging Align tested boolean/Boolean expectations

### DIFF
--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/ClientBackedReadTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/ClientBackedReadTransactionTest.java
@@ -7,14 +7,16 @@
  */
 package org.opendaylight.controller.cluster.databroker;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.Optional;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opendaylight.controller.cluster.access.client.ClientActorContext;
 import org.opendaylight.controller.cluster.databroker.actors.dds.ClientSnapshot;
@@ -40,29 +42,26 @@ public class ClientBackedReadTransactionTest extends ClientBackedTransactionTest
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        Mockito.doReturn(CLIENT_ID).when(clientContext).getIdentifier();
-        Mockito.doReturn(TRANSACTION_ID).when(delegate).getIdentifier();
+        doReturn(CLIENT_ID).when(clientContext).getIdentifier();
+        doReturn(TRANSACTION_ID).when(delegate).getIdentifier();
 
-        Mockito.doReturn(Futures.immediateCheckedFuture(Boolean.TRUE)).when(delegate)
-                .exists(YangInstanceIdentifier.EMPTY);
-        Mockito.doReturn(Futures.immediateCheckedFuture(Optional.of(data))).when(delegate)
-                .read(YangInstanceIdentifier.EMPTY);
+        doReturn(Futures.immediateCheckedFuture(Boolean.TRUE)).when(delegate).exists(YangInstanceIdentifier.EMPTY);
+        doReturn(Futures.immediateCheckedFuture(Optional.of(data))).when(delegate).read(YangInstanceIdentifier.EMPTY);
 
         object = new ClientBackedReadTransaction(delegate, null, null);
     }
 
     @Test
     public void testRead() throws Exception {
-        final ListenableFuture<Optional<NormalizedNode<?, ?>>> result = object().read(
-                YangInstanceIdentifier.EMPTY);
+        final ListenableFuture<Optional<NormalizedNode<?, ?>>> result = object().read(YangInstanceIdentifier.EMPTY);
         final Optional<NormalizedNode<?, ?>> resultData = result.get();
-        Assert.assertTrue(resultData.isPresent());
-        Assert.assertEquals(data, resultData.get());
+        assertTrue(resultData.isPresent());
+        assertEquals(data, resultData.get());
     }
 
     @Test
     public void testExists() throws Exception {
         final ListenableFuture<Boolean> result = object().exists(YangInstanceIdentifier.EMPTY);
-        Assert.assertTrue(result.get());
+        assertEquals(Boolean.TRUE, result.get());
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/ClientBackedReadWriteTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/ClientBackedReadWriteTransactionTest.java
@@ -7,14 +7,16 @@
  */
 package org.opendaylight.controller.cluster.databroker;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.Futures;
 import java.util.Optional;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opendaylight.controller.cluster.databroker.actors.dds.ClientTransaction;
 import org.opendaylight.mdsal.dom.spi.store.DOMStoreThreePhaseCommitCohort;
@@ -41,13 +43,11 @@ public class ClientBackedReadWriteTransactionTest
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        Mockito.doReturn(TRANSACTION_ID).when(delegate).getIdentifier();
-        Mockito.doReturn(readyCohort).when(delegate).ready();
+        doReturn(TRANSACTION_ID).when(delegate).getIdentifier();
+        doReturn(readyCohort).when(delegate).ready();
 
-        Mockito.doReturn(Futures.immediateCheckedFuture(Boolean.TRUE)).when(delegate)
-                .exists(YangInstanceIdentifier.EMPTY);
-        Mockito.doReturn(Futures.immediateCheckedFuture(Optional.of(data))).when(delegate)
-                .read(YangInstanceIdentifier.EMPTY);
+        doReturn(Futures.immediateCheckedFuture(Boolean.TRUE)).when(delegate).exists(YangInstanceIdentifier.EMPTY);
+        doReturn(Futures.immediateCheckedFuture(Optional.of(data))).when(delegate).read(YangInstanceIdentifier.EMPTY);
 
         object = new ClientBackedReadWriteTransaction(delegate, null);
     }
@@ -56,12 +56,12 @@ public class ClientBackedReadWriteTransactionTest
     public void testRead() throws Exception {
         final FluentFuture<Optional<NormalizedNode<?, ?>>> result = object().read(YangInstanceIdentifier.EMPTY);
         final Optional<NormalizedNode<?, ?>> resultData = result.get();
-        Assert.assertTrue(resultData.isPresent());
-        Assert.assertEquals(data, resultData.get());
+        assertTrue(resultData.isPresent());
+        assertEquals(data, resultData.get());
     }
 
     @Test
     public void testExists() throws Exception {
-        Assert.assertTrue(object().exists(YangInstanceIdentifier.EMPTY).get());
+        assertEquals(Boolean.TRUE, object().exists(YangInstanceIdentifier.EMPTY).get());
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/ClientSnapshotTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/ClientSnapshotTest.java
@@ -7,13 +7,14 @@
  */
 package org.opendaylight.controller.cluster.databroker.actors.dds;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opendaylight.controller.cluster.databroker.actors.dds.TestUtils.getWithTimeout;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.Optional;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
@@ -44,14 +45,14 @@ public class ClientSnapshotTest extends AbstractClientHandleTest<ClientSnapshot>
     public void testExists() throws Exception {
         final ListenableFuture<Boolean> exists = getHandle().exists(PATH);
         verify(getDataTreeSnapshot()).readNode(PATH);
-        Assert.assertFalse(getWithTimeout(exists));
+        assertEquals(Boolean.FALSE, getWithTimeout(exists));
     }
 
     @Test
     public void testRead() throws Exception {
         final ListenableFuture<Optional<NormalizedNode<?, ?>>> exists = getHandle().read(PATH);
         verify(getDataTreeSnapshot()).readNode(PATH);
-        Assert.assertFalse(getWithTimeout(exists).isPresent());
+        assertFalse(getWithTimeout(exists).isPresent());
     }
 
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/ClientTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/ClientTransactionTest.java
@@ -7,6 +7,8 @@
  */
 package org.opendaylight.controller.cluster.databroker.actors.dds;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opendaylight.controller.cluster.databroker.actors.dds.TestUtils.TRANSACTION_ID;
@@ -17,7 +19,6 @@ import static org.opendaylight.controller.cluster.databroker.actors.dds.TestUtil
 import com.google.common.util.concurrent.FluentFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.Optional;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -79,7 +80,7 @@ public class ClientTransactionTest extends AbstractClientHandleTest<ClientTransa
     public void testExists() throws Exception {
         final FluentFuture<Boolean> exists = getHandle().exists(PATH);
         verify(modification).readNode(PATH);
-        Assert.assertTrue(getWithTimeout(exists));
+        assertEquals(Boolean.TRUE, getWithTimeout(exists));
     }
 
     @Test
@@ -87,8 +88,8 @@ public class ClientTransactionTest extends AbstractClientHandleTest<ClientTransa
         final FluentFuture<Optional<NormalizedNode<?, ?>>> resultFuture = getHandle().read(PATH);
         verify(modification).readNode(PATH);
         final Optional<NormalizedNode<?, ?>> result = getWithTimeout(resultFuture);
-        Assert.assertTrue(result.isPresent());
-        Assert.assertEquals(DATA, result.get());
+        assertTrue(result.isPresent());
+        assertEquals(DATA, result.get());
     }
 
     @Test
@@ -112,7 +113,7 @@ public class ClientTransactionTest extends AbstractClientHandleTest<ClientTransa
     @Test
     public void testReadyEmpty() throws Exception {
         final DOMStoreThreePhaseCommitCohort cohort = getHandle().ready();
-        assertFutureEquals(true, cohort.canCommit());
+        assertFutureEquals(Boolean.TRUE, cohort.canCommit());
         assertFutureEquals(null, cohort.preCommit());
         assertFutureEquals(null, cohort.commit());
     }
@@ -125,8 +126,8 @@ public class ClientTransactionTest extends AbstractClientHandleTest<ClientTransa
         final ListenableFuture<Boolean> actual = cohort.canCommit();
         final CommitLocalTransactionRequest request =
                 backendRespondToRequest(CommitLocalTransactionRequest.class, response);
-        Assert.assertEquals(modification, request.getModification());
-        assertFutureEquals(true, actual);
+        assertEquals(modification, request.getModification());
+        assertFutureEquals(Boolean.TRUE, actual);
         assertFutureEquals(null, cohort.preCommit());
         assertFutureEquals(null, cohort.commit());
     }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/DirectTransactionCommitCohortTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/DirectTransactionCommitCohortTest.java
@@ -7,6 +7,9 @@
  */
 package org.opendaylight.controller.cluster.databroker.actors.dds;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.opendaylight.controller.cluster.databroker.actors.dds.TestUtils.CLIENT_ID;
 import static org.opendaylight.controller.cluster.databroker.actors.dds.TestUtils.HISTORY_ID;
@@ -20,7 +23,6 @@ import com.google.common.primitives.UnsignedLong;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.Optional;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -66,32 +68,32 @@ public class DirectTransactionCommitCohortTest {
     public void testCanCommit() throws Exception {
         final ListenableFuture<Boolean> canCommit = cohort.canCommit();
         final ModifyTransactionRequest request = transaction.expectTransactionRequest(ModifyTransactionRequest.class);
-        Assert.assertTrue(request.getPersistenceProtocol().isPresent());
-        Assert.assertEquals(PersistenceProtocol.SIMPLE, request.getPersistenceProtocol().get());
+        assertTrue(request.getPersistenceProtocol().isPresent());
+        assertEquals(PersistenceProtocol.SIMPLE, request.getPersistenceProtocol().get());
         final RequestSuccess<?, ?> success = new TransactionCommitSuccess(transaction.getTransaction().getIdentifier(),
                 transaction.getLastReceivedMessage().getSequence());
         transaction.replySuccess(success);
-        Assert.assertTrue(getWithTimeout(canCommit));
+        assertEquals(Boolean.TRUE, getWithTimeout(canCommit));
     }
 
     @Test
     public void testPreCommit() throws Exception {
         final ListenableFuture<Void> preCommit = cohort.preCommit();
-        Assert.assertNull(getWithTimeout(preCommit));
+        assertNull(getWithTimeout(preCommit));
     }
 
     @Test
     public void testAbort() throws Exception {
         final ListenableFuture<Void> abort = cohort.abort();
         verify(history).onTransactionComplete(transaction.getTransaction().getIdentifier());
-        Assert.assertNull(getWithTimeout(abort));
+        assertNull(getWithTimeout(abort));
     }
 
     @Test
     public void testCommit() throws Exception {
         final ListenableFuture<Void> commit = cohort.commit();
         verify(history).onTransactionComplete(transaction.getTransaction().getIdentifier());
-        Assert.assertNull(getWithTimeout(commit));
+        assertNull(getWithTimeout(commit));
     }
 
     private static TransactionTester<?> createTransactionTester(final TestProbe backendProbe,

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/EmptyTransactionCommitCohortTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/EmptyTransactionCommitCohortTest.java
@@ -7,6 +7,8 @@
  */
 package org.opendaylight.controller.cluster.databroker.actors.dds;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.opendaylight.controller.cluster.databroker.actors.dds.TestUtils.TRANSACTION_ID;
 import static org.opendaylight.controller.cluster.databroker.actors.dds.TestUtils.getWithTimeout;
@@ -34,20 +36,20 @@ public class EmptyTransactionCommitCohortTest {
     @Test
     public void testCanCommit() throws Exception {
         final ListenableFuture<Boolean> canCommit = cohort.canCommit();
-        Assert.assertTrue(getWithTimeout(canCommit));
+        assertEquals(Boolean.TRUE, getWithTimeout(canCommit));
     }
 
     @Test
     public void testPreCommit() throws Exception {
         final ListenableFuture<Void> preCommit = cohort.preCommit();
-        Assert.assertNull(getWithTimeout(preCommit));
+        assertNull(getWithTimeout(preCommit));
     }
 
     @Test
     public void testAbort() throws Exception {
         final ListenableFuture<Void> abort = cohort.abort();
         verify(history).onTransactionComplete(TRANSACTION_ID);
-        Assert.assertNull(getWithTimeout(abort));
+        assertNull(getWithTimeout(abort));
     }
 
     @Test

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/LocalProxyTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/LocalProxyTransactionTest.java
@@ -44,8 +44,8 @@ public abstract class LocalProxyTransactionTest<T extends LocalProxyTransaction>
     @Override
     @Test
     public void testExists() throws Exception {
-        assertFutureEquals(true, transaction.exists(PATH_1));
-        assertFutureEquals(false, transaction.exists(PATH_3));
+        assertFutureEquals(Boolean.TRUE, transaction.exists(PATH_1));
+        assertFutureEquals(Boolean.FALSE, transaction.exists(PATH_3));
     }
 
     @Override

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/LocalReadWriteProxyTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/databroker/actors/dds/LocalReadWriteProxyTransactionTest.java
@@ -83,7 +83,7 @@ public class LocalReadWriteProxyTransactionTest extends LocalProxyTransactionTes
         final TransactionTester<LocalReadWriteProxyTransaction> tester = getTester();
         final CommitLocalTransactionRequest req = tester.expectTransactionRequest(CommitLocalTransactionRequest.class);
         tester.replySuccess(new TransactionCommitSuccess(TRANSACTION_ID, req.getSequence()));
-        assertFutureEquals(true, result);
+        assertFutureEquals(Boolean.TRUE, result);
     }
 
     @Test

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/AbstractClusterRefActorTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/AbstractClusterRefActorTest.java
@@ -25,7 +25,7 @@ public abstract class AbstractClusterRefActorTest extends AbstractTest {
 
     @AfterClass
     public static void tearDownClass() {
-        TestKit.shutdownActorSystem(system, Boolean.TRUE);
+        TestKit.shutdownActorSystem(system, true);
         system = null;
     }
 

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/AbstractShardTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/AbstractShardTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractShardTest extends AbstractActorTest {
                 Props.create(new DelegatingShardCreator(creator)).withDispatcher(Dispatchers.DefaultDispatcherId()),
                 "testRecovery");
 
-        assertEquals("Recovery complete", true, recoveryComplete.await(5, TimeUnit.SECONDS));
+        assertTrue("Recovery complete", recoveryComplete.await(5, TimeUnit.SECONDS));
 
         // Verify data in the data store.
 

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/AbstractTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/AbstractTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractTest {
     @After
     public void actorSystemCleanup() {
         for (final ActorSystem system : actorSystems) {
-            TestKit.shutdownActorSystem(system, Boolean.TRUE);
+            TestKit.shutdownActorSystem(system, true);
         }
     }
 

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DataTreeChangeListenerProxyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DataTreeChangeListenerProxyTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -70,7 +72,7 @@ public class DataTreeChangeListenerProxyTest extends AbstractActorTest {
         RegisterDataTreeChangeListener registerMsg = kit.expectMsgClass(timeout,
             RegisterDataTreeChangeListener.class);
         assertEquals("getPath", path, registerMsg.getPath());
-        assertEquals("isRegisterOnAllInstances", false, registerMsg.isRegisterOnAllInstances());
+        assertFalse("isRegisterOnAllInstances", registerMsg.isRegisterOnAllInstances());
 
         kit.reply(new RegisterDataTreeNotificationListenerReply(kit.getRef()));
 
@@ -120,7 +122,7 @@ public class DataTreeChangeListenerProxyTest extends AbstractActorTest {
         RegisterDataTreeChangeListener registerMsg = kit.expectMsgClass(timeout,
             RegisterDataTreeChangeListener.class);
         assertEquals("getPath", path, registerMsg.getPath());
-        assertEquals("isRegisterOnAllInstances", true, registerMsg.isRegisterOnAllInstances());
+        assertTrue("isRegisterOnAllInstances", registerMsg.isRegisterOnAllInstances());
 
         proxy.close();
     }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DatastoreContextIntrospectorTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DatastoreContextIntrospectorTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.opendaylight.controller.cluster.datastore.DatastoreContext.DEFAULT_HEARTBEAT_INTERVAL_IN_MILLIS;
@@ -67,7 +69,7 @@ public class DatastoreContextIntrospectorTest {
         DatastoreContext context = introspector.getContext();
 
         assertEquals(1000, context.getShardBatchedModificationCount());
-        assertEquals(false, context.isTransactionDebugContextEnabled());
+        assertFalse(context.isTransactionDebugContextEnabled());
     }
 
     @Test
@@ -96,7 +98,7 @@ public class DatastoreContextIntrospectorTest {
         properties.put("persistent", "false");
 
         boolean updated = introspector.update(properties);
-        assertEquals("updated", true, updated);
+        assertTrue("updated", updated);
         DatastoreContext context = introspector.getContext();
 
         assertEquals(31, context.getShardTransactionIdleTimeout().toMinutes());
@@ -117,7 +119,7 @@ public class DatastoreContextIntrospectorTest {
         assertEquals(1111, context.getDataStoreProperties().getMaxDataChangeExecutorQueueSize());
         assertEquals(2222, context.getDataStoreProperties().getMaxDataChangeListenerQueueSize());
         assertEquals(3333, context.getDataStoreProperties().getMaxDataStoreExecutorQueueSize());
-        assertEquals(false, context.isPersistent());
+        assertFalse(context.isPersistent());
 
         properties.put("shard-transaction-idle-timeout-in-minutes", "32");
         properties.put("operation-timeout-in-seconds", "27");
@@ -128,7 +130,7 @@ public class DatastoreContextIntrospectorTest {
         properties.put("persistent", "true");
 
         updated = introspector.update(properties);
-        assertEquals("updated", true, updated);
+        assertTrue("updated", updated);
         context = introspector.getContext();
 
         assertEquals(32, context.getShardTransactionIdleTimeout().toMinutes());
@@ -148,13 +150,13 @@ public class DatastoreContextIntrospectorTest {
         assertEquals(1111, context.getDataStoreProperties().getMaxDataChangeExecutorQueueSize());
         assertEquals(2222, context.getDataStoreProperties().getMaxDataChangeListenerQueueSize());
         assertEquals(4444, context.getDataStoreProperties().getMaxDataStoreExecutorQueueSize());
-        assertEquals(true, context.isPersistent());
+        assertTrue(context.isPersistent());
 
         updated = introspector.update(null);
-        assertEquals("updated", false, updated);
+        assertFalse("updated", updated);
 
         updated = introspector.update(new Hashtable<>());
-        assertEquals("updated", false, updated);
+        assertFalse("updated", updated);
     }
 
 
@@ -176,7 +178,7 @@ public class DatastoreContextIntrospectorTest {
         properties.put("unknownProperty", "1"); // bad - invalid property name
 
         final boolean updated = introspector.update(properties);
-        assertEquals("updated", true, updated);
+        assertTrue("updated", updated);
         DatastoreContext context = introspector.getContext();
 
         assertEquals(DEFAULT_SHARD_TRANSACTION_IDLE_TIMEOUT, context.getShardTransactionIdleTimeout());
@@ -210,20 +212,20 @@ public class DatastoreContextIntrospectorTest {
 
         final DatastoreContextIntrospector operIntrospector = INTROSPECTOR_FACTORY.newInstance(OPERATIONAL);
         boolean updated = operIntrospector.update(properties);
-        assertEquals("updated", true, updated);
+        assertTrue("updated", updated);
         DatastoreContext operContext = operIntrospector.getContext();
 
         assertEquals(33, operContext.getShardTransactionIdleTimeout().toMinutes());
-        assertEquals(true, operContext.isPersistent());
+        assertTrue(operContext.isPersistent());
         assertEquals(333, operContext.getDataStoreProperties().getMaxDataChangeExecutorPoolSize());
 
         final DatastoreContextIntrospector configIntrospector = INTROSPECTOR_FACTORY.newInstance(CONFIGURATION);
         updated = configIntrospector.update(properties);
-        assertEquals("updated", true, updated);
+        assertTrue("updated", updated);
         DatastoreContext configContext = configIntrospector.getContext();
 
         assertEquals(44, configContext.getShardTransactionIdleTimeout().toMinutes());
-        assertEquals(false, configContext.isPersistent());
+        assertFalse(configContext.isPersistent());
         assertEquals(444, configContext.getDataStoreProperties().getMaxDataChangeExecutorPoolSize());
     }
 

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DistributedDataStoreIntegrationTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DistributedDataStoreIntegrationTest.java
@@ -8,6 +8,7 @@
 package org.opendaylight.controller.cluster.datastore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -119,7 +120,7 @@ public class DistributedDataStoreIntegrationTest {
 
     @After
     public void tearDown() {
-        TestKit.shutdownActorSystem(system, Boolean.TRUE);
+        TestKit.shutdownActorSystem(system, true);
         system = null;
     }
 
@@ -179,11 +180,11 @@ public class DistributedDataStoreIntegrationTest {
             final DOMStoreReadTransaction readTx = dataStore.newReadOnlyTransaction();
 
             Optional<NormalizedNode<?, ?>> optional = readTx.read(carPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", car, optional.get());
 
             optional = readTx.read(personPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", person, optional.get());
         }
     }
@@ -205,10 +206,10 @@ public class DistributedDataStoreIntegrationTest {
 
             // 3. Read the data from Tx
             final Boolean exists = readWriteTx.exists(nodePath).get(5, TimeUnit.SECONDS);
-            assertEquals("exists", true, exists);
+            assertEquals("exists", Boolean.TRUE, exists);
 
             Optional<NormalizedNode<?, ?>> optional = readWriteTx.read(nodePath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", nodeToWrite, optional.get());
 
             // 4. Ready the Tx for commit
@@ -221,7 +222,7 @@ public class DistributedDataStoreIntegrationTest {
             final DOMStoreReadTransaction readTx = dataStore.newReadOnlyTransaction();
 
             optional = readTx.read(nodePath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", nodeToWrite, optional.get());
         }
     }
@@ -258,10 +259,10 @@ public class DistributedDataStoreIntegrationTest {
             readWriteTx.write(personPath, person);
 
             final Boolean exists = readWriteTx.exists(carPath).get(5, TimeUnit.SECONDS);
-            assertEquals("exists", true, exists);
+            assertEquals("exists", Boolean.TRUE, exists);
 
             Optional<NormalizedNode<?, ?>> optional = readWriteTx.read(carPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", car, optional.get());
 
             testKit.doCommit(readWriteTx.ready());
@@ -270,11 +271,11 @@ public class DistributedDataStoreIntegrationTest {
             DOMStoreReadTransaction readTx = dataStore.newReadOnlyTransaction();
 
             optional = readTx.read(carPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", car, optional.get());
 
             optional = readTx.read(personPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", person, optional.get());
         }
     }
@@ -304,7 +305,7 @@ public class DistributedDataStoreIntegrationTest {
 
             final Optional<NormalizedNode<?, ?>> optional = txChain.newReadOnlyTransaction()
                     .read(CarsModel.CAR_LIST_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("# cars", numCars, ((Collection<?>) optional.get().getValue()).size());
         }
     }
@@ -368,7 +369,7 @@ public class DistributedDataStoreIntegrationTest {
                 throw caughtEx.get();
             }
 
-            assertEquals("Tx ready", true, done);
+            assertTrue("Tx ready", done);
 
             // At this point the Tx operations should be waiting for the
             // shard to initialize so
@@ -382,13 +383,13 @@ public class DistributedDataStoreIntegrationTest {
             final DOMStoreReadTransaction readTx = dataStore.newReadOnlyTransaction();
 
             Optional<NormalizedNode<?, ?>> optional = readTx.read(TestModel.TEST_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
 
             optional = readTx.read(TestModel.OUTER_LIST_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
 
             optional = readTx.read(listEntryPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", false, optional.isPresent());
+            assertFalse("isPresent", optional.isPresent());
         }
     }
 
@@ -452,7 +453,7 @@ public class DistributedDataStoreIntegrationTest {
                 throw caughtEx.get();
             }
 
-            assertEquals("Tx reads done", true, done);
+            assertTrue("Tx reads done", done);
 
             // At this point the Tx operations should be waiting for the
             // shard to initialize so
@@ -460,8 +461,8 @@ public class DistributedDataStoreIntegrationTest {
             blockRecoveryLatch.countDown();
 
             // Wait for the reads to complete and verify.
-            assertEquals("exists", true, txExistsFuture.get().get(5, TimeUnit.SECONDS));
-            assertEquals("read", true, txReadFuture.get().get(5, TimeUnit.SECONDS).isPresent());
+            assertEquals("exists", Boolean.TRUE, txExistsFuture.get().get(5, TimeUnit.SECONDS));
+            assertTrue("read", txReadFuture.get().get(5, TimeUnit.SECONDS).isPresent());
 
             readWriteTx.close();
         }
@@ -516,7 +517,7 @@ public class DistributedDataStoreIntegrationTest {
             throw caughtEx.get();
         }
 
-        assertEquals("Tx ready", true, done);
+        assertTrue("Tx ready", done);
 
         // Wait for the commit to complete. Since the shard never
         // initialized, the Tx should
@@ -584,7 +585,7 @@ public class DistributedDataStoreIntegrationTest {
                 throw caughtEx.get();
             }
 
-            assertEquals("Tx read done", true, done);
+            assertTrue("Tx read done", done);
 
             // Wait for the read to complete. Since the shard never
             // initialized, the Tx should
@@ -659,7 +660,7 @@ public class DistributedDataStoreIntegrationTest {
                     throw caughtEx.get();
                 }
 
-                assertEquals("Tx ready", true, done);
+                assertTrue("Tx ready", done);
 
                 // Wait for the commit to complete. Since no shard
                 // leader was elected in time, the Tx
@@ -764,7 +765,7 @@ public class DistributedDataStoreIntegrationTest {
             // Tx is visible after being readied.
             DOMStoreReadTransaction readTx = txChain.newReadOnlyTransaction();
             Optional<NormalizedNode<?, ?>> optional = readTx.read(TestModel.TEST_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", testNode, optional.get());
 
             // 6. Create a new RW Tx from the chain, write more data,
@@ -781,7 +782,7 @@ public class DistributedDataStoreIntegrationTest {
             // verify it is visible.
             readTx = txChain.newReadWriteTransaction();
             optional = readTx.read(TestModel.OUTER_LIST_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", outerNode, optional.get());
 
             // 8. Wait for the 2 commits to complete and close the
@@ -801,7 +802,7 @@ public class DistributedDataStoreIntegrationTest {
             // committed data.
             readTx = dataStore.newReadOnlyTransaction();
             optional = readTx.read(TestModel.OUTER_LIST_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", outerNode, optional.get());
         }
     }
@@ -836,11 +837,11 @@ public class DistributedDataStoreIntegrationTest {
             readWriteTx.merge(personPath, person);
 
             Optional<NormalizedNode<?, ?>> optional = readWriteTx.read(carPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", car, optional.get());
 
             optional = readWriteTx.read(personPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", person, optional.get());
 
             final DOMStoreThreePhaseCommitCohort cohort2 = readWriteTx.ready();
@@ -863,10 +864,10 @@ public class DistributedDataStoreIntegrationTest {
             final DOMStoreReadTransaction readTx = dataStore.newReadOnlyTransaction();
 
             optional = readTx.read(carPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", false, optional.isPresent());
+            assertFalse("isPresent", optional.isPresent());
 
             optional = readTx.read(personPath).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", person, optional.get());
         }
     }
@@ -908,7 +909,7 @@ public class DistributedDataStoreIntegrationTest {
 
             final Optional<NormalizedNode<?, ?>> optional = txChain.newReadOnlyTransaction()
                     .read(LogicalDatastoreType.CONFIGURATION, CarsModel.CAR_LIST_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("# cars", numCars, ((Collection<?>) optional.get().getValue()).size());
 
             txChain.close();
@@ -931,9 +932,8 @@ public class DistributedDataStoreIntegrationTest {
 
             final DOMStoreReadWriteTransaction rwTx2 = txChain.newReadWriteTransaction();
 
-            final Optional<NormalizedNode<?, ?>> optional = rwTx2.read(TestModel.TEST_PATH).get(
-                5, TimeUnit.SECONDS);
-            assertEquals("isPresent", false, optional.isPresent());
+            final Optional<NormalizedNode<?, ?>> optional = rwTx2.read(TestModel.TEST_PATH).get(5, TimeUnit.SECONDS);
+            assertFalse("isPresent", optional.isPresent());
 
             txChain.close();
         }
@@ -1002,8 +1002,8 @@ public class DistributedDataStoreIntegrationTest {
 
             // Ensure the reads succeed.
 
-            assertEquals("isPresent", true, readFuture1.get(5, TimeUnit.SECONDS).isPresent());
-            assertEquals("isPresent", true, readFuture2.get(5, TimeUnit.SECONDS).isPresent());
+            assertTrue("isPresent", readFuture1.get(5, TimeUnit.SECONDS).isPresent());
+            assertTrue("isPresent", readFuture2.get(5, TimeUnit.SECONDS).isPresent());
 
             // Ensure the writes succeed.
             DOMStoreThreePhaseCommitCohort cohort2 = writeTx2.ready();
@@ -1011,7 +1011,7 @@ public class DistributedDataStoreIntegrationTest {
             testKit.doCommit(cohort1);
             testKit.doCommit(cohort2);
 
-            assertEquals("isPresent", true, txChain.newReadOnlyTransaction().read(TestModel.OUTER_LIST_PATH)
+            assertTrue("isPresent", txChain.newReadOnlyTransaction().read(TestModel.OUTER_LIST_PATH)
                 .get(5, TimeUnit.SECONDS).isPresent());
         }
     }
@@ -1191,11 +1191,11 @@ public class DistributedDataStoreIntegrationTest {
 
             // two reads
             Optional<NormalizedNode<?, ?>> optional = readTx.read(CarsModel.BASE_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", carsNode, optional.get());
 
             optional = readTx.read(PeopleModel.BASE_PATH).get(5, TimeUnit.SECONDS);
-            assertEquals("isPresent", true, optional.isPresent());
+            assertTrue("isPresent", optional.isPresent());
             assertEquals("Data node", peopleNode, optional.get());
         }
     }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DistributedDataStoreRemotingIntegrationTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/DistributedDataStoreRemotingIntegrationTest.java
@@ -8,6 +8,7 @@
 package org.opendaylight.controller.cluster.datastore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -217,7 +218,7 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
     private static void verifyCars(final DOMStoreReadTransaction readTx, final MapEntryNode... entries)
             throws Exception {
         final Optional<NormalizedNode<?, ?>> optional = readTx.read(CarsModel.CAR_LIST_PATH).get(5, TimeUnit.SECONDS);
-        assertEquals("isPresent", true, optional.isPresent());
+        assertTrue("isPresent", optional.isPresent());
 
         final CollectionNodeBuilder<MapEntryNode, MapNode> listBuilder = ImmutableNodes.mapNodeBuilder(
                 CarsModel.CAR_QNAME);
@@ -231,14 +232,14 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
     private static void verifyNode(final DOMStoreReadTransaction readTx, final YangInstanceIdentifier path,
             final NormalizedNode<?, ?> expNode) throws Exception {
         final Optional<NormalizedNode<?, ?>> optional = readTx.read(path).get(5, TimeUnit.SECONDS);
-        assertEquals("isPresent", true, optional.isPresent());
+        assertTrue("isPresent", optional.isPresent());
         assertEquals("Data node", expNode, optional.get());
     }
 
     private static void verifyExists(final DOMStoreReadTransaction readTx, final YangInstanceIdentifier path)
             throws Exception {
         final Boolean exists = readTx.exists(path).get(5, TimeUnit.SECONDS);
-        assertEquals("exists", true, exists);
+        assertEquals("exists", Boolean.TRUE, exists);
     }
 
     @Test
@@ -315,8 +316,8 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
             Uninterruptibles.sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
         }
 
-        TestKit.shutdownActorSystem(leaderSystem, Boolean.TRUE);
-        TestKit.shutdownActorSystem(followerSystem, Boolean.TRUE);
+        TestKit.shutdownActorSystem(leaderSystem, true);
+        TestKit.shutdownActorSystem(followerSystem, true);
 
         final ActorSystem newSystem = newActorSystem("reinstated-member2", "Member2");
 
@@ -476,11 +477,11 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
         readWriteTx.merge(personPath, person);
 
         Optional<NormalizedNode<?, ?>> optional = readWriteTx.read(carPath).get(5, TimeUnit.SECONDS);
-        assertEquals("isPresent", true, optional.isPresent());
+        assertTrue("isPresent", optional.isPresent());
         assertEquals("Data node", car, optional.get());
 
         optional = readWriteTx.read(personPath).get(5, TimeUnit.SECONDS);
-        assertEquals("isPresent", true, optional.isPresent());
+        assertTrue("isPresent", optional.isPresent());
         assertEquals("Data node", person, optional.get());
 
         final DOMStoreThreePhaseCommitCohort cohort2 = readWriteTx.ready();
@@ -500,7 +501,7 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
         verifyCars(readTx, car);
 
         optional = readTx.read(personPath).get(5, TimeUnit.SECONDS);
-        assertEquals("isPresent", false, optional.isPresent());
+        assertFalse("isPresent", optional.isPresent());
     }
 
     @Test
@@ -638,7 +639,7 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
 
         final com.google.common.base.Optional<ActorRef> carsFollowerShard =
                 followerDistributedDataStore.getActorContext().findLocalShard("cars");
-        assertEquals("Cars follower shard found", true, carsFollowerShard.isPresent());
+        assertTrue("Cars follower shard found", carsFollowerShard.isPresent());
 
         final DataTree dataTree = new InMemoryDataTreeFactory().create(
             DataTreeConfiguration.DEFAULT_OPERATIONAL, SchemaContextHelper.full());
@@ -706,7 +707,7 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
 
         final com.google.common.base.Optional<ActorRef> carsFollowerShard =
                 followerDistributedDataStore.getActorContext().findLocalShard("cars");
-        assertEquals("Cars follower shard found", true, carsFollowerShard.isPresent());
+        assertTrue("Cars follower shard found", carsFollowerShard.isPresent());
 
         carsFollowerShard.get().tell(GetShardDataTree.INSTANCE, followerTestKit.getRef());
         final DataTree dataTree = followerTestKit.expectMsgClass(DataTree.class);
@@ -1143,7 +1144,7 @@ public class DistributedDataStoreRemotingIntegrationTest extends AbstractTest {
 
         final Optional<NormalizedNode<?, ?>> readOptional = leaderDistributedDataStore.newReadOnlyTransaction().read(
                 CarsModel.BASE_PATH).get(5, TimeUnit.SECONDS);
-        assertEquals("isPresent", true, readOptional.isPresent());
+        assertTrue("isPresent", readOptional.isPresent());
         assertEquals("Node", carsNode, readOptional.get());
 
         verifySnapshot(InMemorySnapshotStore.waitForSavedSnapshot(leaderCarShardName, Snapshot.class),

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/IntegrationTestKit.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/IntegrationTestKit.java
@@ -9,6 +9,7 @@ package org.opendaylight.controller.cluster.datastore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import akka.actor.ActorRef;
@@ -346,13 +347,13 @@ public class IntegrationTestKit extends ShardTestKit {
         DOMStoreReadTransaction readTx = dataStore.newReadOnlyTransaction();
 
         Optional<NormalizedNode<?, ?>> optional = readTx.read(nodePath).get(5, TimeUnit.SECONDS);
-        assertEquals("isPresent", true, optional.isPresent());
+        assertTrue("isPresent", optional.isPresent());
         assertEquals("Data node", nodeToWrite, optional.get());
     }
 
     public void doCommit(final DOMStoreThreePhaseCommitCohort cohort) throws Exception {
         Boolean canCommit = cohort.canCommit().get(commitTimeout, TimeUnit.SECONDS);
-        assertEquals("canCommit", true, canCommit);
+        assertEquals("canCommit", Boolean.TRUE, canCommit);
         cohort.preCommit().get(5, TimeUnit.SECONDS);
         cohort.commit().get(5, TimeUnit.SECONDS);
     }
@@ -360,7 +361,7 @@ public class IntegrationTestKit extends ShardTestKit {
     void doCommit(final ListenableFuture<Boolean> canCommitFuture, final DOMStoreThreePhaseCommitCohort cohort)
             throws Exception {
         Boolean canCommit = canCommitFuture.get(commitTimeout, TimeUnit.SECONDS);
-        assertEquals("canCommit", true, canCommit);
+        assertEquals("canCommit", Boolean.TRUE, canCommit);
         cohort.preCommit().get(5, TimeUnit.SECONDS);
         cohort.commit().get(5, TimeUnit.SECONDS);
     }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/ShardDataTreeTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/ShardDataTreeTest.java
@@ -10,6 +10,7 @@ package org.opendaylight.controller.cluster.datastore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -298,11 +299,11 @@ public class ShardDataTreeTest extends AbstractTest {
         final DataTreeSnapshot snapshot =
                 shardDataTree.newReadOnlyTransaction(nextTransactionId()).getSnapshot();
         Optional<NormalizedNode<?, ?>> optional = snapshot.readNode(carPath);
-        assertEquals("Car node present", true, optional.isPresent());
+        assertTrue("Car node present", optional.isPresent());
         assertEquals("Car node", carNode, optional.get());
 
         optional = snapshot.readNode(PeopleModel.BASE_PATH);
-        assertEquals("People node present", true, optional.isPresent());
+        assertTrue("People node present", optional.isPresent());
         assertEquals("People node", peopleNode, optional.get());
     }
 
@@ -345,7 +346,7 @@ public class ShardDataTreeTest extends AbstractTest {
         final DataTreeSnapshot snapshot =
                 shardDataTree.newReadOnlyTransaction(nextTransactionId()).getSnapshot();
         Optional<NormalizedNode<?, ?>> optional = snapshot.readNode(carPath);
-        assertEquals("Car node present", true, optional.isPresent());
+        assertTrue("Car node present", optional.isPresent());
         assertEquals("Car node", carNode, optional.get());
     }
 
@@ -372,10 +373,9 @@ public class ShardDataTreeTest extends AbstractTest {
         inOrder.verify(commitCallback2).onSuccess(any(UnsignedLong.class));
         inOrder.verify(commitCallback3).onSuccess(any(UnsignedLong.class));
 
-        final DataTreeSnapshot snapshot =
-                shardDataTree.newReadOnlyTransaction(nextTransactionId()).getSnapshot();
+        final DataTreeSnapshot snapshot = shardDataTree.newReadOnlyTransaction(nextTransactionId()).getSnapshot();
         Optional<NormalizedNode<?, ?>> optional = snapshot.readNode(CarsModel.BASE_PATH);
-        assertEquals("Car node present", true, optional.isPresent());
+        assertTrue("Car node present", optional.isPresent());
     }
 
     @SuppressWarnings("unchecked")
@@ -431,7 +431,7 @@ public class ShardDataTreeTest extends AbstractTest {
         final DataTreeSnapshot snapshot =
                 shardDataTree.newReadOnlyTransaction(nextTransactionId()).getSnapshot();
         Optional<NormalizedNode<?, ?>> optional = snapshot.readNode(carPath);
-        assertEquals("Car node present", true, optional.isPresent());
+        assertTrue("Car node present", optional.isPresent());
         assertEquals("Car node", carNode, optional.get());
     }
 
@@ -471,7 +471,7 @@ public class ShardDataTreeTest extends AbstractTest {
         final DataTreeSnapshot snapshot =
                 shardDataTree.newReadOnlyTransaction(nextTransactionId()).getSnapshot();
         Optional<NormalizedNode<?, ?>> optional = snapshot.readNode(PeopleModel.BASE_PATH);
-        assertEquals("People node present", true, optional.isPresent());
+        assertTrue("People node present", optional.isPresent());
         assertEquals("People node", peopleNode, optional.get());
     }
 
@@ -504,7 +504,7 @@ public class ShardDataTreeTest extends AbstractTest {
 
         final Optional<NormalizedNode<?, ?>> optional = snapshot1.readNode(CarsModel.BASE_PATH);
 
-        assertEquals(true, optional.isPresent());
+        assertTrue(optional.isPresent());
 
         return optional.get();
     }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/ShardTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/ShardTest.java
@@ -194,7 +194,7 @@ public class ShardTest extends AbstractShardTest {
                 "testDataTreeChangeListenerNotifiedWhenNotTheLeaderOnRegistration");
 
         final ShardTestKit testKit = new ShardTestKit(getSystem());
-        assertEquals("Got first ElectionTimeout", true, onFirstElectionTimeout.await(5, TimeUnit.SECONDS));
+        assertTrue("Got first ElectionTimeout", onFirstElectionTimeout.await(5, TimeUnit.SECONDS));
 
         shard.tell(new RegisterDataTreeChangeListener(path, dclActor, false), testKit.getRef());
         final RegisterDataTreeNotificationListenerReply reply = testKit.expectMsgClass(testKit.duration("5 seconds"),
@@ -441,9 +441,8 @@ public class ShardTest extends AbstractShardTest {
 
             @Override
             void onSuccess(final Object resp) {
-                final CanCommitTransactionReply canCommitReply =
-                        CanCommitTransactionReply.fromSerializable(resp);
-                assertEquals("Can commit", true, canCommitReply.getCanCommit());
+                final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply.fromSerializable(resp);
+                assertTrue("Can commit", canCommitReply.getCanCommit());
 
                 final Future<Object> commitFuture = Patterns.ask(shard,
                         new CommitTransaction(transactionID, CURRENT_VERSION).toSerializable(), timeout);
@@ -474,7 +473,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID1, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         // Ready 2 more Tx's.
 
@@ -521,7 +520,7 @@ public class ShardTest extends AbstractShardTest {
             throw new RuntimeException(t);
         }
 
-        assertEquals("Commits complete", true, done);
+        assertTrue("Commits complete", done);
 
 //                final InOrder inOrder = inOrder(cohort1.getCanCommit(), cohort1.getPreCommit(), cohort1.getCommit(),
 //                        cohort2.getCanCommit(), cohort2.getPreCommit(), cohort2.getCommit(), cohort3.getCanCommit(),
@@ -580,7 +579,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         // Send the CommitTransaction message.
 
@@ -731,7 +730,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID1, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         shard.tell(new CommitTransaction(transactionID1, CURRENT_VERSION).toSerializable(), testKit.getRef());
         testKit.expectMsgClass(duration, CommitTransactionReply.class);
@@ -906,7 +905,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(txId, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         // Send the CanCommitTransaction message.
 
@@ -942,7 +941,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         // Send the CanCommitTransaction message.
 
@@ -990,7 +989,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         shard.tell(new CommitTransaction(transactionID, CURRENT_VERSION).toSerializable(), testKit.getRef());
         testKit.expectMsgClass(duration, CommitTransactionReply.class);
@@ -1051,7 +1050,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID1, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         // Send the CanCommitTransaction message for the 2nd Tx. This
         // should get queued and
@@ -1077,7 +1076,7 @@ public class ShardTest extends AbstractShardTest {
             }
         }, getSystem().dispatcher());
 
-        assertEquals("2nd CanCommit complete", true, latch.await(5, TimeUnit.SECONDS));
+        assertTrue("2nd CanCommit complete", latch.await(5, TimeUnit.SECONDS));
 
         final InOrder inOrder = inOrder(dataTree);
         inOrder.verify(dataTree).validate(any(DataTreeModification.class));
@@ -1121,7 +1120,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID1, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         // Send the CanCommitTransaction message for the 2nd Tx. This
         // should get queued and
@@ -1147,7 +1146,7 @@ public class ShardTest extends AbstractShardTest {
             }
         }, getSystem().dispatcher());
 
-        assertEquals("2nd CanCommit complete", true, latch.await(5, TimeUnit.SECONDS));
+        assertTrue("2nd CanCommit complete", latch.await(5, TimeUnit.SECONDS));
 
         final InOrder inOrder = inOrder(dataTree);
         inOrder.verify(dataTree).validate(any(DataTreeModification.class));
@@ -1191,7 +1190,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID2, CURRENT_VERSION).toSerializable(), testKit.getRef());
         final CanCommitTransactionReply reply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(CanCommitTransactionReply.class));
-        assertEquals("getCanCommit", true, reply.getCanCommit());
+        assertTrue("getCanCommit", reply.getCanCommit());
     }
 
     @Test
@@ -1549,7 +1548,7 @@ public class ShardTest extends AbstractShardTest {
         shard.tell(new CanCommitTransaction(transactionID1, CURRENT_VERSION).toSerializable(), testKit.getRef());
         CanCommitTransactionReply canCommitReply = CanCommitTransactionReply
                 .fromSerializable(testKit.expectMsgClass(duration, CanCommitTransactionReply.class));
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
 
         // Send the CanCommitTransaction message for the 2nd Tx. This
         // should get queued and
@@ -1568,7 +1567,7 @@ public class ShardTest extends AbstractShardTest {
         // Wait for the 2nd Tx to complete the canCommit phase.
 
         canCommitReply = (CanCommitTransactionReply) Await.result(canCommitFuture, duration);
-        assertEquals("Can commit", true, canCommitReply.getCanCommit());
+        assertTrue("Can commit", canCommitReply.getCanCommit());
     }
 
     @Test
@@ -1738,7 +1737,7 @@ public class ShardTest extends AbstractShardTest {
     private static void awaitAndValidateSnapshot(final AtomicReference<CountDownLatch> latch,
             final AtomicReference<Object> savedSnapshot, final NormalizedNode<?, ?> expectedRoot)
                     throws InterruptedException {
-        assertEquals("Snapshot saved", true, latch.get().await(5, TimeUnit.SECONDS));
+        assertTrue("Snapshot saved", latch.get().await(5, TimeUnit.SECONDS));
 
         assertTrue("Invalid saved snapshot " + savedSnapshot.get(), savedSnapshot.get() instanceof Snapshot);
 
@@ -1811,17 +1810,17 @@ public class ShardTest extends AbstractShardTest {
 
         final TestActorRef<Shard> shard = actorFactory.createTestActor(newShardProps(), "testOnDatastoreContext");
 
-        assertEquals("isRecoveryApplicable", true, shard.underlyingActor().persistence().isRecoveryApplicable());
+        assertTrue("isRecoveryApplicable", shard.underlyingActor().persistence().isRecoveryApplicable());
 
         ShardTestKit.waitUntilLeader(shard);
 
         shard.tell(dataStoreContextBuilder.persistent(false).build(), ActorRef.noSender());
 
-        assertEquals("isRecoveryApplicable", false, shard.underlyingActor().persistence().isRecoveryApplicable());
+        assertFalse("isRecoveryApplicable", shard.underlyingActor().persistence().isRecoveryApplicable());
 
         shard.tell(dataStoreContextBuilder.persistent(true).build(), ActorRef.noSender());
 
-        assertEquals("isRecoveryApplicable", true, shard.underlyingActor().persistence().isRecoveryApplicable());
+        assertTrue("isRecoveryApplicable", shard.underlyingActor().persistence().isRecoveryApplicable());
     }
 
     @Test
@@ -1841,8 +1840,7 @@ public class ShardTest extends AbstractShardTest {
 
         ShardLeaderStateChanged leaderStateChanged = MessageCollectorActor.expectFirstMatching(listener,
             ShardLeaderStateChanged.class);
-        assertEquals("getLocalShardDataTree present", true,
-            leaderStateChanged.getLocalShardDataTree().isPresent());
+        assertTrue("getLocalShardDataTree present", leaderStateChanged.getLocalShardDataTree().isPresent());
         assertSame("getLocalShardDataTree", shard.underlyingActor().getDataStore().getDataTree(),
             leaderStateChanged.getLocalShardDataTree().get());
 
@@ -1852,9 +1850,8 @@ public class ShardTest extends AbstractShardTest {
 
         shard.tell(new RequestVote(10000, "member2", 50, 50), testKit.getRef());
 
-        leaderStateChanged = MessageCollectorActor.expectFirstMatching(listener,
-            ShardLeaderStateChanged.class);
-        assertEquals("getLocalShardDataTree present", false, leaderStateChanged.getLocalShardDataTree().isPresent());
+        leaderStateChanged = MessageCollectorActor.expectFirstMatching(listener, ShardLeaderStateChanged.class);
+        assertFalse("getLocalShardDataTree present", leaderStateChanged.getLocalShardDataTree().isPresent());
     }
 
     @Test
@@ -1866,12 +1863,12 @@ public class ShardTest extends AbstractShardTest {
         shard.underlyingActor().handleNonRaftCommand(new FollowerInitialSyncUpStatus(false,
                 "member-1-shard-inventory-operational"));
 
-        assertEquals(false, shard.underlyingActor().getShardMBean().getFollowerInitialSyncStatus());
+        assertFalse(shard.underlyingActor().getShardMBean().getFollowerInitialSyncStatus());
 
         shard.underlyingActor().handleNonRaftCommand(new FollowerInitialSyncUpStatus(true,
                 "member-1-shard-inventory-operational"));
 
-        assertEquals(true, shard.underlyingActor().getShardMBean().getFollowerInitialSyncStatus());
+        assertTrue(shard.underlyingActor().getShardMBean().getFollowerInitialSyncStatus());
     }
 
     @Test

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/TransactionChainProxyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/TransactionChainProxyTest.java
@@ -8,7 +8,7 @@
 
 package org.opendaylight.controller.cluster.datastore;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -162,7 +162,7 @@ public class TransactionChainProxyTest extends AbstractTransactionProxyTest {
                 }
             }).start();
 
-            assertEquals("Tx 2 write should've completed", true, write2Complete.await(5, TimeUnit.SECONDS));
+            assertTrue("Tx 2 write should've completed", write2Complete.await(5, TimeUnit.SECONDS));
 
             if (caughtEx.get() != null) {
                 throw caughtEx.get();
@@ -231,7 +231,7 @@ public class TransactionChainProxyTest extends AbstractTransactionProxyTest {
                 }
             }).start();
 
-            assertEquals("Tx 2 write should've completed", true, write2Complete.await(5, TimeUnit.SECONDS));
+            assertTrue("Tx 2 write should've completed", write2Complete.await(5, TimeUnit.SECONDS));
 
             if (caughtEx.get() != null) {
                 throw caughtEx.get();

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/TransactionProxyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/TransactionProxyTest.java
@@ -9,6 +9,7 @@
 package org.opendaylight.controller.cluster.datastore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -105,7 +106,7 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
         Optional<NormalizedNode<?, ?>> readOptional = transactionProxy.read(
                 TestModel.TEST_PATH).get(5, TimeUnit.SECONDS);
 
-        assertEquals("NormalizedNode isPresent", false, readOptional.isPresent());
+        assertFalse("NormalizedNode isPresent", readOptional.isPresent());
 
         NormalizedNode<?, ?> expectedNode = ImmutableNodes.containerNode(TestModel.TEST_QNAME);
 
@@ -114,7 +115,7 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
 
         readOptional = transactionProxy.read(TestModel.TEST_PATH).get(5, TimeUnit.SECONDS);
 
-        assertEquals("NormalizedNode isPresent", true, readOptional.isPresent());
+        assertTrue("NormalizedNode isPresent", readOptional.isPresent());
 
         assertEquals("Response NormalizedNode", expectedNode, readOptional.get());
     }
@@ -204,7 +205,7 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
         Optional<NormalizedNode<?, ?>> readOptional = transactionProxy.read(
                 TestModel.TEST_PATH).get(5, TimeUnit.SECONDS);
 
-        assertEquals("NormalizedNode isPresent", true, readOptional.isPresent());
+        assertTrue("NormalizedNode isPresent", readOptional.isPresent());
         assertEquals("Response NormalizedNode", expectedNode, readOptional.get());
 
         InOrder inOrder = Mockito.inOrder(mockActorContext);
@@ -251,14 +252,14 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
 
         Boolean exists = transactionProxy.exists(TestModel.TEST_PATH).get();
 
-        assertEquals("Exists response", false, exists);
+        assertEquals("Exists response", Boolean.FALSE, exists);
 
         doReturn(dataExistsReply(true)).when(mockActorContext).executeOperationAsync(
                 eq(actorSelection(actorRef)), eqDataExists(), any(Timeout.class));
 
         exists = transactionProxy.exists(TestModel.TEST_PATH).get();
 
-        assertEquals("Exists response", true, exists);
+        assertEquals("Exists response", Boolean.TRUE, exists);
     }
 
     @Test(expected = PrimaryNotFoundException.class)
@@ -312,7 +313,7 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
 
         Boolean exists = transactionProxy.exists(TestModel.TEST_PATH).get();
 
-        assertEquals("Exists response", true, exists);
+        assertEquals("Exists response", Boolean.TRUE, exists);
 
         InOrder inOrder = Mockito.inOrder(mockActorContext);
         inOrder.verify(mockActorContext).executeOperationAsync(
@@ -572,22 +573,19 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
         ArgumentCaptor<BatchedModifications> batchedMods = ArgumentCaptor.forClass(BatchedModifications.class);
         verify(mockActorContext).executeOperationAsync(
                 eq(actorSelection(actorRef1)), batchedMods.capture(), any(Timeout.class));
-        assertEquals("Participating shards present", true,
-                batchedMods.getValue().getParticipatingShardNames().isPresent());
+        assertTrue("Participating shards present", batchedMods.getValue().getParticipatingShardNames().isPresent());
         assertEquals("Participating shards", expShardNames, batchedMods.getValue().getParticipatingShardNames().get());
 
         batchedMods = ArgumentCaptor.forClass(BatchedModifications.class);
         verify(mockActorContext).executeOperationAsync(
                 eq(actorSelection(actorRef2)), batchedMods.capture(), any(Timeout.class));
-        assertEquals("Participating shards present", true,
-                batchedMods.getValue().getParticipatingShardNames().isPresent());
+        assertTrue("Participating shards present", batchedMods.getValue().getParticipatingShardNames().isPresent());
         assertEquals("Participating shards", expShardNames, batchedMods.getValue().getParticipatingShardNames().get());
 
         ArgumentCaptor<ReadyLocalTransaction> readyLocalTx = ArgumentCaptor.forClass(ReadyLocalTransaction.class);
         verify(mockActorContext).executeOperationAsync(
                 eq(actorSelection(actorRef3)), readyLocalTx.capture(), any(Timeout.class));
-        assertEquals("Participating shards present", true,
-                readyLocalTx.getValue().getParticipatingShardNames().isPresent());
+        assertTrue("Participating shards present", readyLocalTx.getValue().getParticipatingShardNames().isPresent());
         assertEquals("Participating shards", expShardNames, readyLocalTx.getValue().getParticipatingShardNames().get());
     }
 
@@ -710,8 +708,7 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
         ArgumentCaptor<ReadyLocalTransaction> readyLocalTx = ArgumentCaptor.forClass(ReadyLocalTransaction.class);
         verify(mockActorContext).executeOperationAsync(
                 eq(actorSelection(shardActorRef)), readyLocalTx.capture(), any(Timeout.class));
-        assertEquals("Participating shards present", false,
-                readyLocalTx.getValue().getParticipatingShardNames().isPresent());
+        assertFalse("Participating shards present", readyLocalTx.getValue().getParticipatingShardNames().isPresent());
     }
 
     @Test
@@ -1413,7 +1410,7 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
 
         Optional<NormalizedNode<?, ?>> readOptional = transactionProxy.read(writePath2).get(5, TimeUnit.SECONDS);
 
-        assertEquals("NormalizedNode isPresent", true, readOptional.isPresent());
+        assertTrue("NormalizedNode isPresent", readOptional.isPresent());
         assertEquals("Response NormalizedNode", writeNode2, readOptional.get());
 
         transactionProxy.merge(mergePath1, mergeNode1);
@@ -1424,9 +1421,9 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
         transactionProxy.delete(deletePath);
 
         Boolean exists = transactionProxy.exists(TestModel.TEST_PATH).get();
-        assertEquals("Exists response", true, exists);
+        assertEquals("Exists response", Boolean.TRUE, exists);
 
-        assertEquals("NormalizedNode isPresent", true, readOptional.isPresent());
+        assertTrue("NormalizedNode isPresent", readOptional.isPresent());
         assertEquals("Response NormalizedNode", mergeNode2, readOptional.get());
 
         List<BatchedModifications> batchedModifications = captureBatchedModifications(actorRef);
@@ -1484,7 +1481,7 @@ public class TransactionProxyTest extends AbstractTransactionProxyTest {
         Optional<NormalizedNode<?, ?>> readOptional = transactionProxy.read(
                 YangInstanceIdentifier.EMPTY).get(5, TimeUnit.SECONDS);
 
-        assertEquals("NormalizedNode isPresent", true, readOptional.isPresent());
+        assertTrue("NormalizedNode isPresent", readOptional.isPresent());
 
         NormalizedNode<?, ?> normalizedNode = readOptional.get();
 

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/actors/ShardSnapshotActorTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/actors/ShardSnapshotActorTest.java
@@ -9,6 +9,7 @@ package org.opendaylight.controller.cluster.datastore.actors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import akka.actor.ActorRef;
 import akka.testkit.javadsl.TestKit;
@@ -56,7 +57,7 @@ public class ShardSnapshotActorTest extends AbstractActorTest {
             assertEquals("Deserialized snapshot type", snapshot.getClass(), deserialized.getClass());
 
             final Optional<NormalizedNode<?, ?>> maybeNode = deserialized.getRootNode();
-            assertEquals("isPresent", true, maybeNode.isPresent());
+            assertTrue("isPresent", maybeNode.isPresent());
             assertEquals("Root node", expectedRoot, maybeNode.get());
         }
     }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/entityownership/DistributedEntityOwnershipIntegrationTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/entityownership/DistributedEntityOwnershipIntegrationTest.java
@@ -790,7 +790,8 @@ public class DistributedEntityOwnershipIntegrationTest {
 
         Future<Object> future = Patterns.ask(leaderDistributedDataStore.getActorContext().getShardManager(),
                 new ChangeShardMembersVotingStatus(ENTITY_OWNERSHIP_SHARD_NAME,
-                        ImmutableMap.of("member-4", false, "member-5", false)), new Timeout(10, TimeUnit.SECONDS));
+                        ImmutableMap.of("member-4", Boolean.FALSE, "member-5", Boolean.FALSE)),
+                new Timeout(10, TimeUnit.SECONDS));
         Object response = Await.result(future, FiniteDuration.apply(10, TimeUnit.SECONDS));
         if (response instanceof Throwable) {
             throw new AssertionError("ChangeShardMembersVotingStatus failed", (Throwable)response);
@@ -823,7 +824,7 @@ public class DistributedEntityOwnershipIntegrationTest {
 
         future = Patterns.ask(leaderDistributedDataStore.getActorContext().getShardManager(),
                 new ChangeShardMembersVotingStatus(ENTITY_OWNERSHIP_SHARD_NAME,
-                        ImmutableMap.of("member-3", false, "member-4", true, "member-5", true)),
+                        ImmutableMap.of("member-3", Boolean.FALSE, "member-4", Boolean.TRUE, "member-5", Boolean.TRUE)),
                 new Timeout(10, TimeUnit.SECONDS));
         response = Await.result(future, FiniteDuration.apply(10, TimeUnit.SECONDS));
         if (response instanceof Throwable) {
@@ -852,7 +853,7 @@ public class DistributedEntityOwnershipIntegrationTest {
                     .read(entityPath(entity.getType(), entity.getIdentifier()).node(Candidate.QNAME))
                     .get(5, TimeUnit.SECONDS);
             try {
-                assertEquals("Candidates not found for " + entity, true, possible.isPresent());
+                assertTrue("Candidates not found for " + entity, possible.isPresent());
                 Collection<String> actual = new ArrayList<>();
                 for (MapEntryNode candidate: ((MapNode)possible.get()).getValue()) {
                     actual.add(candidate.getChild(CANDIDATE_NAME_NODE_ID).get().getValue().toString());

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/entityownership/DistributedEntityOwnershipServiceTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/entityownership/DistributedEntityOwnershipServiceTest.java
@@ -249,7 +249,7 @@ public class DistributedEntityOwnershipServiceTest extends AbstractClusterRefEnt
 
         DOMEntity entity2 = new DOMEntity(ENTITY_TYPE, "two");
         Optional<EntityOwnershipState> state = service.getOwnershipState(entity2);
-        assertEquals("getOwnershipState present", false, state.isPresent());
+        assertFalse("getOwnershipState present", state.isPresent());
 
         writeNode(ENTITY_OWNERS_PATH, entityOwnersWithCandidate(ENTITY_TYPE, entity2.getIdentifier(), "member-1"),
                 shardDataTree);
@@ -259,7 +259,7 @@ public class DistributedEntityOwnershipServiceTest extends AbstractClusterRefEnt
 
         deleteNode(candidatePath(entityPath(entity2.getType(), entity2.getIdentifier()), "member-1"), shardDataTree);
         Optional<EntityOwnershipState> state2 = service.getOwnershipState(entity2);
-        assertEquals("getOwnershipState present", false, state2.isPresent());
+        assertFalse("getOwnershipState present", state2.isPresent());
         service.close();
     }
 
@@ -282,7 +282,7 @@ public class DistributedEntityOwnershipServiceTest extends AbstractClusterRefEnt
     private static void verifyGetOwnershipState(final DistributedEntityOwnershipService service, final DOMEntity entity,
             final EntityOwnershipState expState) {
         Optional<EntityOwnershipState> state = service.getOwnershipState(entity);
-        assertEquals("getOwnershipState present", true, state.isPresent());
+        assertTrue("getOwnershipState present", state.isPresent());
         assertEquals("EntityOwnershipState", expState, state.get());
     }
 

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/AbortTransactionReplyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/AbortTransactionReplyTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -34,7 +36,7 @@ public class AbortTransactionReplyTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, AbortTransactionReply.isSerializedType(new AbortTransactionReply()));
-        assertEquals("isSerializedType", false, AbortTransactionReply.isSerializedType(new Object()));
+        assertTrue("isSerializedType", AbortTransactionReply.isSerializedType(new AbortTransactionReply()));
+        assertFalse("isSerializedType", AbortTransactionReply.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/AbortTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/AbortTransactionTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -39,7 +41,7 @@ public class AbortTransactionTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, AbortTransaction.isSerializedType(new AbortTransaction()));
-        assertEquals("isSerializedType", false, AbortTransaction.isSerializedType(new Object()));
+        assertTrue("isSerializedType", AbortTransaction.isSerializedType(new AbortTransaction()));
+        assertFalse("isSerializedType", AbortTransaction.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/BatchedModificationsTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/BatchedModificationsTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableSortedSet;
 import java.io.Serializable;
@@ -52,9 +54,9 @@ public class BatchedModificationsTest extends AbstractTest {
         batched.addModification(new WriteModification(writePath, writeData));
         batched.addModification(new MergeModification(mergePath, mergeData));
         batched.addModification(new DeleteModification(deletePath));
-        assertEquals("isReady", false, batched.isReady());
+        assertFalse("isReady", batched.isReady());
         batched.setReady();
-        assertEquals("isReady", true, batched.isReady());
+        assertTrue("isReady", batched.isReady());
         batched.setTotalMessagesSent(5);
 
         BatchedModifications clone = (BatchedModifications) SerializationUtils.clone(
@@ -62,9 +64,9 @@ public class BatchedModificationsTest extends AbstractTest {
 
         assertEquals("getVersion", DataStoreVersions.CURRENT_VERSION, clone.getVersion());
         assertEquals("getTransactionID", tx1, clone.getTransactionId());
-        assertEquals("isReady", true, clone.isReady());
-        assertEquals("isDoCommitOnReady", false, clone.isDoCommitOnReady());
-        assertEquals("participatingShardNames present", false, clone.getParticipatingShardNames().isPresent());
+        assertTrue("isReady", clone.isReady());
+        assertFalse("isDoCommitOnReady", clone.isDoCommitOnReady());
+        assertFalse("participatingShardNames present", clone.getParticipatingShardNames().isPresent());
         assertEquals("getTotalMessagesSent", 5, clone.getTotalMessagesSent());
 
         assertEquals("getModifications size", 3, clone.getModifications().size());
@@ -90,15 +92,15 @@ public class BatchedModificationsTest extends AbstractTest {
         final SortedSet<String> shardNames = ImmutableSortedSet.of("one", "two");
         batched.setReady(Optional.of(shardNames));
         batched.setDoCommitOnReady(true);
-        assertEquals("isReady", true, batched.isReady());
+        assertTrue("isReady", batched.isReady());
 
         clone = (BatchedModifications) SerializationUtils.clone((Serializable) batched.toSerializable());
 
         assertEquals("getVersion", DataStoreVersions.CURRENT_VERSION, clone.getVersion());
         assertEquals("getTransactionID", tx2, clone.getTransactionId());
-        assertEquals("isReady", true, clone.isReady());
-        assertEquals("isDoCommitOnReady", true, clone.isDoCommitOnReady());
-        assertEquals("participatingShardNames present", true, clone.getParticipatingShardNames().isPresent());
+        assertTrue("isReady", clone.isReady());
+        assertTrue("isDoCommitOnReady", clone.isDoCommitOnReady());
+        assertTrue("participatingShardNames present", clone.getParticipatingShardNames().isPresent());
         assertEquals("participatingShardNames", shardNames, clone.getParticipatingShardNames().get());
         assertEquals("getModifications size", 0, clone.getModifications().size());
 
@@ -110,7 +112,7 @@ public class BatchedModificationsTest extends AbstractTest {
 
         assertEquals("getVersion", DataStoreVersions.CURRENT_VERSION, clone.getVersion());
         assertEquals("getTransactionID", tx2, clone.getTransactionId());
-        assertEquals("isReady", false, clone.isReady());
+        assertFalse("isReady", clone.isReady());
         assertEquals("getModifications size", 0, clone.getModifications().size());
 
         // Test pre-Flourine
@@ -123,8 +125,8 @@ public class BatchedModificationsTest extends AbstractTest {
 
         assertEquals("getVersion", DataStoreVersions.BORON_VERSION, clone.getVersion());
         assertEquals("getTransactionID", tx2, clone.getTransactionId());
-        assertEquals("isReady", true, clone.isReady());
-        assertEquals("participatingShardNames present", false, clone.getParticipatingShardNames().isPresent());
+        assertTrue("isReady", clone.isReady());
+        assertFalse("participatingShardNames present", clone.getParticipatingShardNames().isPresent());
         assertEquals("getModifications size", 1, clone.getModifications().size());
     }
 

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CanCommitTransactionReplyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CanCommitTransactionReplyTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -41,8 +43,7 @@ public class CanCommitTransactionReplyTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, CanCommitTransactionReply.isSerializedType(
-                new CanCommitTransactionReply()));
-        assertEquals("isSerializedType", false, CanCommitTransactionReply.isSerializedType(new Object()));
+        assertTrue("isSerializedType", CanCommitTransactionReply.isSerializedType(new CanCommitTransactionReply()));
+        assertFalse("isSerializedType", CanCommitTransactionReply.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CanCommitTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CanCommitTransactionTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -38,7 +40,7 @@ public class CanCommitTransactionTest extends AbstractTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, CanCommitTransaction.isSerializedType(new CanCommitTransaction()));
-        assertEquals("isSerializedType", false, CanCommitTransaction.isSerializedType(new Object()));
+        assertTrue("isSerializedType", CanCommitTransaction.isSerializedType(new CanCommitTransaction()));
+        assertFalse("isSerializedType", CanCommitTransaction.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CloseTransactionChainTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CloseTransactionChainTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -37,7 +39,7 @@ public class CloseTransactionChainTest extends AbstractTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, CloseTransactionChain.isSerializedType(new CloseTransactionChain()));
-        assertEquals("isSerializedType", false, CloseTransactionChain.isSerializedType(new Object()));
+        assertTrue("isSerializedType", CloseTransactionChain.isSerializedType(new CloseTransactionChain()));
+        assertFalse("isSerializedType", CloseTransactionChain.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CommitTransactionReplyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CommitTransactionReplyTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -34,7 +36,7 @@ public class CommitTransactionReplyTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, CommitTransactionReply.isSerializedType(new CommitTransactionReply()));
-        assertEquals("isSerializedType", false, CommitTransactionReply.isSerializedType(new Object()));
+        assertTrue("isSerializedType", CommitTransactionReply.isSerializedType(new CommitTransactionReply()));
+        assertFalse("isSerializedType", CommitTransactionReply.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CommitTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CommitTransactionTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -37,7 +39,7 @@ public class CommitTransactionTest extends AbstractTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, CommitTransaction.isSerializedType(new CommitTransaction()));
-        assertEquals("isSerializedType", false, CommitTransaction.isSerializedType(new Object()));
+        assertTrue("isSerializedType", CommitTransaction.isSerializedType(new CommitTransaction()));
+        assertFalse("isSerializedType", CommitTransaction.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CreateTransactionReplyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CreateTransactionReplyTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -39,7 +41,7 @@ public class CreateTransactionReplyTest extends AbstractTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, CreateTransactionReply.isSerializedType(new CreateTransactionReply()));
-        assertEquals("isSerializedType", false, CreateTransactionReply.isSerializedType(new Object()));
+        assertTrue("isSerializedType", CreateTransactionReply.isSerializedType(new CreateTransactionReply()));
+        assertFalse("isSerializedType", CreateTransactionReply.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CreateTransactionTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/CreateTransactionTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -53,7 +55,7 @@ public class CreateTransactionTest extends AbstractTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, CreateTransaction.isSerializedType(new CreateTransaction()));
-        assertEquals("isSerializedType", false, CreateTransaction.isSerializedType(new Object()));
+        assertTrue("isSerializedType", CreateTransaction.isSerializedType(new CreateTransaction()));
+        assertFalse("isSerializedType", CreateTransaction.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/DataExistsReplyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/DataExistsReplyTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -35,7 +37,7 @@ public class DataExistsReplyTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, DataExistsReply.isSerializedType(new DataExistsReply()));
-        assertEquals("isSerializedType", false, DataExistsReply.isSerializedType(new Object()));
+        assertTrue("isSerializedType", DataExistsReply.isSerializedType(new DataExistsReply()));
+        assertFalse("isSerializedType", DataExistsReply.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/DataExistsTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/DataExistsTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -36,7 +38,7 @@ public class DataExistsTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, DataExists.isSerializedType(new DataExists()));
-        assertEquals("isSerializedType", false, DataExists.isSerializedType(new Object()));
+        assertTrue("isSerializedType", DataExists.isSerializedType(new DataExists()));
+        assertFalse("isSerializedType", DataExists.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/ReadDataReplyTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/ReadDataReplyTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -45,7 +47,7 @@ public class ReadDataReplyTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, ReadDataReply.isSerializedType(new ReadDataReply()));
-        assertEquals("isSerializedType", false, ReadDataReply.isSerializedType(new Object()));
+        assertTrue("isSerializedType", ReadDataReply.isSerializedType(new ReadDataReply()));
+        assertFalse("isSerializedType", ReadDataReply.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/ReadDataTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/ReadDataTest.java
@@ -8,6 +8,8 @@
 package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
@@ -36,7 +38,7 @@ public class ReadDataTest {
 
     @Test
     public void testIsSerializedType() {
-        assertEquals("isSerializedType", true, ReadData.isSerializedType(new ReadData()));
-        assertEquals("isSerializedType", false, ReadData.isSerializedType(new Object()));
+        assertTrue("isSerializedType", ReadData.isSerializedType(new ReadData()));
+        assertFalse("isSerializedType", ReadData.isSerializedType(new Object()));
     }
 }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/ReadyLocalTransactionSerializerTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/messages/ReadyLocalTransactionSerializerTest.java
@@ -9,6 +9,7 @@ package org.opendaylight.controller.cluster.datastore.messages;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import akka.actor.ExtendedActorSystem;
 import akka.testkit.javadsl.TestKit;
@@ -71,9 +72,9 @@ public class ReadyLocalTransactionSerializerTest extends AbstractTest {
         BatchedModifications batched = (BatchedModifications)deserialized;
         assertEquals("getTransactionID", txId, batched.getTransactionId());
         assertEquals("getVersion", DataStoreVersions.CURRENT_VERSION, batched.getVersion());
-        assertEquals("isReady", true, batched.isReady());
-        assertEquals("isDoCommitOnReady", true, batched.isDoCommitOnReady());
-        assertEquals("participatingShardNames present", true, batched.getParticipatingShardNames().isPresent());
+        assertTrue("isReady", batched.isReady());
+        assertTrue("isDoCommitOnReady", batched.isDoCommitOnReady());
+        assertTrue("participatingShardNames present", batched.getParticipatingShardNames().isPresent());
         assertEquals("participatingShardNames", shardNames, batched.getParticipatingShardNames().get());
 
         List<Modification> batchedMods = batched.getModifications();

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/persisted/ShardDataTreeSnapshotTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/persisted/ShardDataTreeSnapshotTest.java
@@ -8,6 +8,7 @@
 package org.opendaylight.controller.cluster.datastore.persisted;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;
@@ -52,7 +53,7 @@ public class ShardDataTreeSnapshotTest {
         }
 
         Optional<NormalizedNode<?, ?>> actualNode = deserialized.getRootNode();
-        assertEquals("rootNode present", true, actualNode.isPresent());
+        assertTrue("rootNode present", actualNode.isPresent());
         assertEquals("rootNode", expectedNode, actualNode.get());
         assertEquals("Deserialized type", MetadataShardDataTreeSnapshot.class, deserialized.getClass());
         assertEquals("Metadata size", 0, ((MetadataShardDataTreeSnapshot)deserialized).getMetadata().size());
@@ -78,7 +79,7 @@ public class ShardDataTreeSnapshotTest {
         }
 
         Optional<NormalizedNode<?, ?>> actualNode = deserialized.getRootNode();
-        assertEquals("rootNode present", true, actualNode.isPresent());
+        assertTrue("rootNode present", actualNode.isPresent());
         assertEquals("rootNode", expectedNode, actualNode.get());
         assertEquals("Deserialized type", MetadataShardDataTreeSnapshot.class, deserialized.getClass());
         assertEquals("Metadata", expMetadata, ((MetadataShardDataTreeSnapshot)deserialized).getMetadata());

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/shardmanager/ShardManagerTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/shardmanager/ShardManagerTest.java
@@ -8,6 +8,7 @@
 package org.opendaylight.controller.cluster.datastore.shardmanager;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -308,7 +309,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
 
         shardManager.tell(new UpdateSchemaContext(TEST_SCHEMA_CONTEXT), kit.getRef());
 
-        assertEquals("Shard actors created", true, newShardActorLatch.await(5, TimeUnit.SECONDS));
+        assertTrue("Shard actors created", newShardActorLatch.await(5, TimeUnit.SECONDS));
         assertEquals("getShardElectionTimeoutFactor", 6,
                 shardInfoMap.get("default").getValue().getShardElectionTimeoutFactor());
         assertEquals("getShardElectionTimeoutFactor", 7,
@@ -1106,7 +1107,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
     public void testByDefaultSyncStatusIsFalse() {
         TestShardManager shardManager = newTestShardManager();
 
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
     }
 
     @Test
@@ -1116,7 +1117,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
         shardManager.onReceiveCommand(new RoleChangeNotification("member-1-shard-default-" + shardMrgIDSuffix,
                 RaftState.Follower.name(), RaftState.Leader.name()));
 
-        assertEquals(true, shardManager.getMBean().getSyncStatus());
+        assertTrue(shardManager.getMBean().getSyncStatus());
     }
 
     @Test
@@ -1127,13 +1128,13 @@ public class ShardManagerTest extends AbstractShardManagerTest {
         shardManager.onReceiveCommand(new RoleChangeNotification(shardId,
                 RaftState.Follower.name(), RaftState.Candidate.name()));
 
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
 
         // Send a FollowerInitialSyncStatus with status = true for the replica whose current state is candidate
         shardManager.onReceiveCommand(new FollowerInitialSyncUpStatus(
                 true, shardId));
 
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
     }
 
     @Test
@@ -1145,17 +1146,17 @@ public class ShardManagerTest extends AbstractShardManagerTest {
                 RaftState.Candidate.name(), RaftState.Follower.name()));
 
         // Initially will be false
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
 
         // Send status true will make sync status true
         shardManager.onReceiveCommand(new FollowerInitialSyncUpStatus(true, shardId));
 
-        assertEquals(true, shardManager.getMBean().getSyncStatus());
+        assertTrue(shardManager.getMBean().getSyncStatus());
 
         // Send status false will make sync status false
         shardManager.onReceiveCommand(new FollowerInitialSyncUpStatus(false, shardId));
 
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
     }
 
     @Test
@@ -1169,7 +1170,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
         }));
 
         // Initially will be false
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
 
         // Make default shard leader
         String defaultShardId = "member-1-shard-default-" + shardMrgIDSuffix;
@@ -1177,7 +1178,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
                 RaftState.Follower.name(), RaftState.Leader.name()));
 
         // default = Leader, astronauts is unknown so sync status remains false
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
 
         // Make astronauts shard leader as well
         String astronautsShardId = "member-1-shard-astronauts-" + shardMrgIDSuffix;
@@ -1185,20 +1186,20 @@ public class ShardManagerTest extends AbstractShardManagerTest {
                 RaftState.Follower.name(), RaftState.Leader.name()));
 
         // Now sync status should be true
-        assertEquals(true, shardManager.getMBean().getSyncStatus());
+        assertTrue(shardManager.getMBean().getSyncStatus());
 
         // Make astronauts a Follower
         shardManager.onReceiveCommand(new RoleChangeNotification(astronautsShardId,
                 RaftState.Leader.name(), RaftState.Follower.name()));
 
         // Sync status is not true
-        assertEquals(false, shardManager.getMBean().getSyncStatus());
+        assertFalse(shardManager.getMBean().getSyncStatus());
 
         // Make the astronauts follower sync status true
         shardManager.onReceiveCommand(new FollowerInitialSyncUpStatus(true, astronautsShardId));
 
         // Sync status is now true
-        assertEquals(true, shardManager.getMBean().getSyncStatus());
+        assertTrue(shardManager.getMBean().getSyncStatus());
 
         LOG.info("testWhenMultipleShardsPresentSyncStatusMustBeTrueForAllShards ending");
     }
@@ -1251,7 +1252,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
 
         kit.expectMsgClass(kit.duration("5 seconds"), LocalShardFound.class);
 
-        assertEquals("isRecoveryApplicable", false, shardBuilder.getDatastoreContext().isPersistent());
+        assertFalse("isRecoveryApplicable", shardBuilder.getDatastoreContext().isPersistent());
         assertTrue("Epxected ShardPeerAddressResolver", shardBuilder.getDatastoreContext().getShardRaftConfig()
             .getPeerAddressResolver() instanceof ShardPeerAddressResolver);
         assertEquals("peerMembers", Sets.newHashSet(
@@ -1443,7 +1444,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
         shardManager.tell(new AddShardReplica("model-inventory"), kit.getRef());
         Status.Failure resp = kit.expectMsgClass(kit.duration("2 seconds"), Status.Failure.class);
 
-        assertEquals("Failure obtained", true, resp.cause() instanceof IllegalArgumentException);
+        assertTrue("Failure obtained", resp.cause() instanceof IllegalArgumentException);
     }
 
     @Test
@@ -1680,7 +1681,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
 
         newReplicaShardManager.tell(new AddShardReplica("astronauts"), kit.getRef());
         Status.Failure resp = kit.expectMsgClass(kit.duration("5 seconds"), Status.Failure.class);
-        assertEquals("Failure obtained", true, resp.cause() instanceof RuntimeException);
+        assertTrue("Failure obtained", resp.cause() instanceof RuntimeException);
 
         LOG.info("testAddShardReplicaWithFindPrimaryTimeout ending");
     }
@@ -1694,7 +1695,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
 
         shardManager.tell(new RemoveShardReplica("model-inventory", MEMBER_1), kit.getRef());
         Status.Failure resp = kit.expectMsgClass(kit.duration("10 seconds"), Status.Failure.class);
-        assertEquals("Failure obtained", true, resp.cause() instanceof PrimaryNotFoundException);
+        assertTrue("Failure obtained", resp.cause() instanceof PrimaryNotFoundException);
     }
 
     @Test
@@ -2052,7 +2053,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
         MessageCollectorActor.expectFirstMatching(respondActor, ChangeServersVotingStatus.class);
 
         Status.Failure resp = kit.expectMsgClass(kit.duration("5 seconds"), Status.Failure.class);
-        assertEquals("Failure resposnse", true, resp.cause() instanceof NoShardLeaderException);
+        assertTrue("Failure resposnse", resp.cause() instanceof NoShardLeaderException);
     }
 
     public static class TestShardManager extends ShardManager {
@@ -2119,37 +2120,36 @@ public class ShardManagerTest extends AbstractShardManagerTest {
         }
 
         void waitForRecoveryComplete() {
-            assertEquals("Recovery complete", true,
+            assertTrue("Recovery complete",
                     Uninterruptibles.awaitUninterruptibly(recoveryComplete, 5, TimeUnit.SECONDS));
         }
 
         public void waitForMemberUp() {
-            assertEquals("MemberUp received", true,
+            assertTrue("MemberUp received",
                     Uninterruptibles.awaitUninterruptibly(memberUpReceived, 5, TimeUnit.SECONDS));
             memberUpReceived = new CountDownLatch(1);
         }
 
         void waitForMemberRemoved() {
-            assertEquals("MemberRemoved received", true,
+            assertTrue("MemberRemoved received",
                     Uninterruptibles.awaitUninterruptibly(memberRemovedReceived, 5, TimeUnit.SECONDS));
             memberRemovedReceived = new CountDownLatch(1);
         }
 
         void waitForUnreachableMember() {
-            assertEquals("UnreachableMember received", true,
-                Uninterruptibles.awaitUninterruptibly(memberUnreachableReceived, 5, TimeUnit.SECONDS
-                ));
+            assertTrue("UnreachableMember received",
+                Uninterruptibles.awaitUninterruptibly(memberUnreachableReceived, 5, TimeUnit.SECONDS));
             memberUnreachableReceived = new CountDownLatch(1);
         }
 
         void waitForReachableMember() {
-            assertEquals("ReachableMember received", true,
+            assertTrue("ReachableMember received",
                 Uninterruptibles.awaitUninterruptibly(memberReachableReceived, 5, TimeUnit.SECONDS));
             memberReachableReceived = new CountDownLatch(1);
         }
 
         void verifyFindPrimary() {
-            assertEquals("FindPrimary received", true,
+            assertTrue("FindPrimary received",
                     Uninterruptibles.awaitUninterruptibly(findPrimaryMessageReceived, 5, TimeUnit.SECONDS));
             findPrimaryMessageReceived = new CountDownLatch(1);
         }
@@ -2186,7 +2186,7 @@ public class ShardManagerTest extends AbstractShardManagerTest {
         }
 
         void verifySnapshotPersisted(final Set<String> shardList) {
-            assertEquals("saveSnapshot invoked", true,
+            assertTrue("saveSnapshot invoked",
                     Uninterruptibles.awaitUninterruptibly(snapshotPersist, 5, TimeUnit.SECONDS));
             assertEquals("Shard Persisted", shardList, Sets.newHashSet(snapshot.getShardList()));
         }

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/utils/ActorContextTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/datastore/utils/ActorContextTest.java
@@ -210,62 +210,60 @@ public class ActorContextTest extends AbstractActorTest {
         ActorContext actorContext = null;
 
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(false, actorContext.isPathLocal(null));
-        assertEquals(false, actorContext.isPathLocal(""));
+        assertFalse(actorContext.isPathLocal(null));
+        assertFalse(actorContext.isPathLocal(""));
 
         clusterWrapper.setSelfAddress(null);
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(false, actorContext.isPathLocal(""));
+        assertFalse(actorContext.isPathLocal(""));
 
         // even if the path is in local format, match the primary path (first 3 elements) and return true
         clusterWrapper.setSelfAddress(new Address("akka", "test"));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(true, actorContext.isPathLocal("akka://test/user/$a"));
+        assertTrue(actorContext.isPathLocal("akka://test/user/$a"));
 
         clusterWrapper.setSelfAddress(new Address("akka", "test"));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(true, actorContext.isPathLocal("akka://test/user/$a"));
+        assertTrue(actorContext.isPathLocal("akka://test/user/$a"));
 
         clusterWrapper.setSelfAddress(new Address("akka", "test"));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(true, actorContext.isPathLocal("akka://test/user/token2/token3/$a"));
+        assertTrue(actorContext.isPathLocal("akka://test/user/token2/token3/$a"));
 
         // self address of remote format,but Tx path local format.
         clusterWrapper.setSelfAddress(new Address("akka", "system", "127.0.0.1", 2550));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(true, actorContext.isPathLocal(
-            "akka://system/user/shardmanager/shard/transaction"));
+        assertTrue(actorContext.isPathLocal("akka://system/user/shardmanager/shard/transaction"));
 
         // self address of local format,but Tx path remote format.
         clusterWrapper.setSelfAddress(new Address("akka", "system"));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(false, actorContext.isPathLocal(
-            "akka://system@127.0.0.1:2550/user/shardmanager/shard/transaction"));
+        assertFalse(actorContext.isPathLocal("akka://system@127.0.0.1:2550/user/shardmanager/shard/transaction"));
 
         //local path but not same
         clusterWrapper.setSelfAddress(new Address("akka", "test"));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(true, actorContext.isPathLocal("akka://test1/user/$a"));
+        assertTrue(actorContext.isPathLocal("akka://test1/user/$a"));
 
         //ip and port same
         clusterWrapper.setSelfAddress(new Address("akka", "system", "127.0.0.1", 2550));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(true, actorContext.isPathLocal("akka://system@127.0.0.1:2550/"));
+        assertTrue(actorContext.isPathLocal("akka://system@127.0.0.1:2550/"));
 
         // forward-slash missing in address
         clusterWrapper.setSelfAddress(new Address("akka", "system", "127.0.0.1", 2550));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(false, actorContext.isPathLocal("akka://system@127.0.0.1:2550"));
+        assertFalse(actorContext.isPathLocal("akka://system@127.0.0.1:2550"));
 
         //ips differ
         clusterWrapper.setSelfAddress(new Address("akka", "system", "127.0.0.1", 2550));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(false, actorContext.isPathLocal("akka://system@127.1.0.1:2550/"));
+        assertFalse(actorContext.isPathLocal("akka://system@127.1.0.1:2550/"));
 
         //ports differ
         clusterWrapper.setSelfAddress(new Address("akka", "system", "127.0.0.1", 2550));
         actorContext = new ActorContext(getSystem(), null, clusterWrapper, mock(Configuration.class));
-        assertEquals(false, actorContext.isPathLocal("akka://system@127.0.0.1:2551/"));
+        assertFalse(actorContext.isPathLocal("akka://system@127.0.0.1:2551/"));
     }
 
     @Test
@@ -341,7 +339,7 @@ public class ActorContextTest extends AbstractActorTest {
         PrimaryShardInfo actual = Await.result(foobar, Duration.apply(5000, TimeUnit.MILLISECONDS));
 
         assertNotNull(actual);
-        assertEquals("LocalShardDataTree present", false, actual.getLocalShardDataTree().isPresent());
+        assertFalse("LocalShardDataTree present", actual.getLocalShardDataTree().isPresent());
         assertTrue("Unexpected PrimaryShardActor path " + actual.getPrimaryShardActor().path(),
                 expPrimaryPath.endsWith(actual.getPrimaryShardActor().pathString()));
         assertEquals("getPrimaryShardVersion", expPrimaryVersion, actual.getPrimaryShardVersion());
@@ -382,7 +380,7 @@ public class ActorContextTest extends AbstractActorTest {
         PrimaryShardInfo actual = Await.result(foobar, Duration.apply(5000, TimeUnit.MILLISECONDS));
 
         assertNotNull(actual);
-        assertEquals("LocalShardDataTree present", true, actual.getLocalShardDataTree().isPresent());
+        assertTrue("LocalShardDataTree present", actual.getLocalShardDataTree().isPresent());
         assertSame("LocalShardDataTree", mockDataTree, actual.getLocalShardDataTree().get());
         assertTrue("Unexpected PrimaryShardActor path " + actual.getPrimaryShardActor().path(),
                 expPrimaryPath.endsWith(actual.getPrimaryShardActor().pathString()));

--- a/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/sharding/DistributedShardedDOMDataTreeRemotingTest.java
+++ b/opendaylight/md-sal/sal-distributed-datastore/src/test/java/org/opendaylight/controller/cluster/sharding/DistributedShardedDOMDataTreeRemotingTest.java
@@ -128,8 +128,8 @@ public class DistributedShardedDOMDataTreeRemotingTest extends AbstractTest {
             followerOperDatastore.close();
         }
 
-        TestKit.shutdownActorSystem(leaderSystem, Boolean.TRUE);
-        TestKit.shutdownActorSystem(followerSystem, Boolean.TRUE);
+        TestKit.shutdownActorSystem(leaderSystem, true);
+        TestKit.shutdownActorSystem(followerSystem, true);
 
         InMemoryJournal.clear();
         InMemorySnapshotStore.clear();


### PR DESCRIPTION
This patch removes implicit boxing/unboxing by aligning boolean/Boolean
expectations.

Future<Boolean>.get() will return a Boolean, hence use assertEquals() for
these (and Optional<Boolean>). Doing that instead of assertTrue()/assertFalse()
eliminates a single Eclipse info-level message about Boolean being unboxes.
This also has better behavior: if the tested method returns null, we'll get
an assertion failure instead of a NPE.

For isPersent() and other methods which return a boolean, use assertTrue()
or assertFalse(). Doing that instead of assertEquals() eliminates two Eclipse
info-level messages about boxing the two arguments to Boolean, for some
reason there is no assertEquals(boolean, boolean).

Change-Id: If86ef9fb1ecf4cdceb45bc079bba1a86cff311ac
Signed-off-by: Robert Varga <robert.varga@pantheon.tech>