### PR TITLE
Construct IMDS delegate with proper type

### DIFF
--- a/opendaylight/md-sal/sal-common-api/src/main/java/org/opendaylight/controller/md/sal/common/api/data/LogicalDatastoreType.java
+++ b/opendaylight/md-sal/sal-common-api/src/main/java/org/opendaylight/controller/md/sal/common/api/data/LogicalDatastoreType.java
@@ -7,8 +7,10 @@
  */
 package org.opendaylight.controller.md.sal.common.api.data;
 
-public enum LogicalDatastoreType {
+import org.eclipse.jdt.annotation.NonNullByDefault;
 
+@NonNullByDefault
+public enum LogicalDatastoreType {
     /**
      * Logical atastore representing operational state of the system
      * and it's components
@@ -18,7 +20,12 @@ public enum LogicalDatastoreType {
      * the system and it's operation related data.
      *
      */
-    OPERATIONAL,
+    OPERATIONAL {
+        @Override
+        public org.opendaylight.mdsal.common.api.LogicalDatastoreType toMdsal() {
+            return org.opendaylight.mdsal.common.api.LogicalDatastoreType.OPERATIONAL;
+        }
+    },
     /**
      * Logical Datastore representing configuration state of the system
      * and it's components.
@@ -28,5 +35,17 @@ public enum LogicalDatastoreType {
      * the system and intended operation mode.
      *
      */
-    CONFIGURATION
+    CONFIGURATION {
+        @Override
+        public org.opendaylight.mdsal.common.api.LogicalDatastoreType toMdsal() {
+            return org.opendaylight.mdsal.common.api.LogicalDatastoreType.CONFIGURATION;
+        }
+    };
+
+    /**
+     * Convert this logical datastore type to its MD-SAL counterpart.
+     *
+     * @return MD-SAL counterpart of this type.
+     */
+    public abstract org.opendaylight.mdsal.common.api.LogicalDatastoreType toMdsal();
 }

--- a/opendaylight/md-sal/sal-inmemory-datastore/src/main/java/org/opendaylight/controller/md/sal/dom/store/impl/InMemoryDOMDataStore.java
+++ b/opendaylight/md-sal/sal-inmemory-datastore/src/main/java/org/opendaylight/controller/md/sal/dom/store/impl/InMemoryDOMDataStore.java
@@ -35,8 +35,8 @@ public class InMemoryDOMDataStore
     public InMemoryDOMDataStore(final String name, final LogicalDatastoreType type,
             final ExecutorService dataChangeListenerExecutor,
             final int maxDataChangeListenerQueueSize, final boolean debugTransactions) {
-        delegate = new org.opendaylight.mdsal.dom.store.inmemory.InMemoryDOMDataStore(name, dataChangeListenerExecutor,
-            maxDataChangeListenerQueueSize, debugTransactions);
+        delegate = new org.opendaylight.mdsal.dom.store.inmemory.InMemoryDOMDataStore(name, type.toMdsal(),
+            dataChangeListenerExecutor, maxDataChangeListenerQueueSize, debugTransactions);
     }
 
     @Override


### PR DESCRIPTION
This patch makes sure we do not ignore the datastore type, but
pass it down to MD-SAL's IMDS.

Since we are converting from controller to mdsal LogicalDatastoreType
in multiple places, centralize this via LogicalDatastoreType.toMdsal().

JIRA: MDSAL-370
Change-Id: I5e027fd439e325ff91344de98511e503fc801992
Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
(cherry picked from commit 0425ce4501aec2d8f96d6379baa1116a5350fba2)

review, test, and merge changes