### PR TITLE
Bump to Dropwizard Metrics 4.0.3

### DIFF
--- a/features/mdsal/odl-mdsal-clustering-commons/pom.xml
+++ b/features/mdsal/odl-mdsal-clustering-commons/pom.xml
@@ -57,11 +57,6 @@
             <artifactId>sal-akka-raft</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>3.1.2</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/opendaylight/md-sal/sal-clustering-commons/pom.xml
+++ b/opendaylight/md-sal/sal-clustering-commons/pom.xml
@@ -94,12 +94,17 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>3.1.2</version>
+      <version>4.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>3.1.2</version>
+      <version>4.0.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jmx</artifactId>
+      <version>4.0.3</version>
     </dependency>
 
     <!-- Google -->

--- a/opendaylight/md-sal/sal-clustering-commons/src/main/java/org/opendaylight/controller/cluster/reporting/MetricsReporter.java
+++ b/opendaylight/md-sal/sal-clustering-commons/src/main/java/org/opendaylight/controller/cluster/reporting/MetricsReporter.java
@@ -7,8 +7,8 @@
  */
 package org.opendaylight.controller.cluster.reporting;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;

--- a/opendaylight/md-sal/sal-remoterpc-connector/pom.xml
+++ b/opendaylight/md-sal/sal-remoterpc-connector/pom.xml
@@ -93,16 +93,6 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>3.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-graphite</artifactId>
-            <version>3.1.2</version>
-        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
This also cleans up some duplicate dependencies.

Release notes:
* 4.0.0: https://metrics.dropwizard.io/4.0.0/about/release-notes.html
* 4.0.1: https://github.com/dropwizard/metrics/releases/tag/v4.0.1
* 4.0.2: https://github.com/dropwizard/metrics/releases/tag/v4.0.1
* 4.0.3: none available, see
  https://github.com/dropwizard/metrics/compare/v4.0.2...v4.0.3

Change-Id: I29050a587aebafcf0d169425242b6281dbb43519